### PR TITLE
Make environment dependency-free and gate optional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+!src/bjjsim/env/
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -2,16 +2,26 @@
 
 Brazilian Jiu-Jitsu multi-agent self-play simulation. This repository will host a Python 3.12, type-hinted, research-grade environment to explore emergent BJJ-like behaviors via simplified rigid-body physics and reinforcement learning self-play.
 
-Status: **Phase 1 Complete** ✅ - UI-First Physics Prototype delivered. Deterministic stepping validated, web UI functional with full API endpoints, frame preview working, and comprehensive test suite verified.
+Status: **Phase 2 In Progress** 🚧 - Phase 1's UI-first physics prototype is complete, and an initial multi-agent environment skeleton now ships with deterministic placeholder observations/rewards for integration testing without external dependencies.
 
-Next target: Phase 2 — Environment and Rewards - Multi-agent Gymnasium environment with observation/action spaces and hierarchical reward components.
+Next focus: Phase 2 — Environment and Rewards - Replace placeholder observations with physics data, add richer reward components, and expose termination signals beyond episode length.
 
 ## What we're building
 
 - Two rigid humanoids in PyBullet interact under simplified physics
-- A custom multi-agent Gymnasium environment (observations/actions/rewards well-defined)
+- A custom multi-agent environment designed to align with Gymnasium semantics once the full dependency stack is available
 - Hierarchical rewards prioritizing: staying on top > control > joint hyperextension > choke
 - Self-play training with RLlib PPO (torch), GUI for debugging and headless for training
+
+## Optional dependencies
+
+The repository vendors only standard-library code to keep tests runnable in constrained environments. Installing the following extras unlocks additional features and tests:
+
+- `fastapi`, `uvicorn`, `pydantic`, `jinja2`, `httpx`, `pillow`: required for the dashboard API and Playwright smoke test
+- `gymnasium`, `numpy`: bring the environment closer to the long-term Gymnasium API plan
+- `playwright`, `pytest-playwright`: enable browser-driven end-to-end tests
+
+When these packages are absent, the related tests are skipped while core physics and environment unit tests continue to run.
 
 ## Documentation (Sphinx)
 
@@ -58,8 +68,8 @@ Once started, the app provides these initial endpoints:
 
 Notes:
 
-- The E2E smoke test launches a local uvicorn subprocess and drives the dashboard.
-- Locally, if browsers are not installed, the E2E test is skipped. In CI, ensure the install step runs.
+- The E2E smoke test launches a local uvicorn subprocess and drives the dashboard when the optional web stack is installed.
+- Locally, if browsers or FastAPI dependencies are not installed, the related tests are skipped. In CI, ensure the install step runs.
 
 ### Troubleshooting
 
@@ -102,12 +112,22 @@ Notes:
 ├── src/
 │   └── bjjsim/
 │       ├── __init__.py
+│       ├── env/
+│       │   └── __init__.py
+│       ├── physics/
+│       │   ├── __init__.py
+│       │   └── adapter.py
 │       └── web/
 │           ├── __init__.py
 │           ├── app.py
 │           └── templates/
 │               └── index.html
 ├── tests/
+│   ├── README.md
+│   ├── conftest.py
+│   ├── test_e2e_smoke.py
+│   ├── test_env.py
+│   ├── test_physics_adapter.py
 │   └── test_web_app.py
 ├── CONTRIBUTING.md
 ├── CODE_OF_CONDUCT.md

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -9,7 +9,7 @@ Components
 - Web UI Control Panel: Local FastAPI-served pages to control evaluation episodes and view metrics/frames
 - Instrumentation: Reward component logging and episode stats
 
-Near-term implementation: FastAPI UI skeleton in `src/bjjsim/web/` exposing typed endpoints and a simple dashboard.
+Near-term implementation: FastAPI UI skeleton in `src/bjjsim/web/` plus an initial Gymnasium environment (`bjjsim.env`) exposing deterministic placeholder observations/rewards for testing.
 
 Key design choices
 

--- a/docs/architecture/env_design.md
+++ b/docs/architecture/env_design.md
@@ -1,117 +1,65 @@
-# Environment Design (Gymnasium, Multi-agent) ✅ IMPLEMENTED
+# Environment Design (Multi-agent Placeholder)
 
-## API Implementation
+## Current Implementation (Phase 2 Scaffold)
 
-- **Two agents**: `agent1`, `agent2` (Dict-based multi-agent environment)
-- **reset(seed) -> (obs, info)** where `obs` is Dict[str, np.ndarray] per agent
-- **step(actions) -> (obs, rewards, terminated, truncated, infos)** per Gymnasium v0.29
-- **Deterministic seeding**: Environment supports seeded resets for reproducible testing
+- **Agents**: Two symmetric agents (`agent1`, `agent2`) exposed via a lightweight `DictSpace` wrapper that mirrors Gymnasium's mapping semantics without requiring external dependencies.
+- **Physics backend**: Defaults to the deterministic `DeterministicCounterAdapter`. Real PyBullet integration remains a future milestone.
+- **Seeding**: `reset(seed=...)` uses Python's `random.Random` seeded from either the provided value or a pseudo-random draw. Identical seeds yield identical observations for repeatability.
+- **Episode accounting**: Tracks both per-episode step count and cumulative steps across the life of the environment instance.
 
-## Observation Space (per agent) - 90 dimensions
+## Observation Space (per agent)
 
-**ACTUAL IMPLEMENTATION:**
-- **Own joint positions**: 12 dimensions (joint angles in radians, range [-π, π])
-- **Own joint velocities**: 12 dimensions (angular velocities, range [-50, 50])
-- **Opponent joint positions**: 12 dimensions (joint angles in radians, range [-π, π])  
-- **Opponent joint velocities**: 12 dimensions (angular velocities, range [-50, 50])
-- **Own base z-position**: 1 dimension (vertical position, range [-10, 10])
-- **Opponent base z-position**: 1 dimension (vertical position, range [-10, 10])
-- **Contact summary vector**: 40 dimensions (8 contacts × 5 features each)
-  - Per contact: [link_pair_id, normal_force, rel_pos_x, rel_pos_y, rel_pos_z]
-  - Range: [0, 1000] for forces, [-1000, 1000] for positions
-- **Total**: 12 + 12 + 12 + 12 + 1 + 1 + 40 = **90 dimensions per agent**
+- **Shape**: 12-dimensional vector of Python `float`s (configurable via `EnvConfig.observation_dim`).
+- **Structure**:
+  1. Episode step count (float)
+  2. Physics adapter step count (float)
+  3. Agent index (0 for `agent1`, 1 for `agent2`)
+  4. Remaining dimensions filled with deterministic pseudo-random values drawn from a uniform distribution in `[observation_low, observation_high]` for quick prototyping.
+- **Bounds**: `[-1000, 1000]` by default; configurable in `EnvConfig`.
+- **Status**: Placeholder values — no real kinematics or contact data yet.
 
-⚠️ **PLACEHOLDER STATUS**: Joint efforts/torques are NOT included in observations (contrary to some design docs). Contact summary uses exponential moving average over recent steps.
+## Action Space (per agent)
 
-## Action Space (per agent) - 12 dimensions
+- **Shape**: 6-dimensional vector (configurable via `EnvConfig.action_dim`).
+- **Bounds**: `[-1, 1]` clipped per component by the `ContinuousSpace` helper.
+- **Usage**: Actions are currently consumed only for reward shaping (energy penalty) and forwarded to the physics adapter as a fixed number of deterministic steps.
 
-- **Continuous torque control**: 12 joints per agent (Box space [-1, 1])
-- **Clipping**: Actions automatically clipped to [-1, 1] range
-- **Physics scaling**: Torques scaled by `max_torque` config (default: ±100.0 Nm)
-- **Space type**: `gymnasium.spaces.Dict` with per-agent `Box(-1, 1, (12,), float32)`
+## Reward System (per agent)
 
-## Hierarchical Reward System
+- **Components**:
+  - `step_reward`: Constant positive reward (default `0.1`) encouraging progress through the episode.
+  - `energy_penalty`: Negative value proportional to the L2 norm of the agent's action vector (`-energy_penalty_scale * ||a||`).
+- **Total reward**: Sum of the components above; stored in the per-agent `infos[agent]["reward_components"]` mapping for instrumentation.
+- **Status**: Minimal scaffolding. Hierarchical BJJ-specific rewards (top control, submissions, etc.) are not implemented yet.
 
-**IMPLEMENTED VALUES (from EnvConfig):**
-- **Choke submission**: +30.0 (highest priority, sustained contact force > 50.0)
-- **Joint hyperextension**: +20.0 (joint limits exceeded with tolerance 0.1 rad)
-- **Top control**: +10.0 (z-position advantage > 0.1 for 5+ steps)
-- **Contact control**: +5.0 (3+ active contacts sustained for 5+ steps) 
-- **Energy penalty**: -0.1 per action magnitude (encourages efficiency)
-- **Reward tracking**: Full component breakdown logged in `reward_history` and step `infos`
+## Termination & Truncation
 
-⚠️ **PLACEHOLDER STATUS**: 
-- Choke detection uses heuristic contact force thresholds (line 398-414)
-- Hyperextension detection is randomized (0.1% chance, line 419-423)
-- Contact forces are simulated random data (line 302-311)
+- **Truncation**: Episodes truncate once `episode_step_count >= max_episode_steps` (default 200). The environment stops issuing further steps until `reset` is called.
+- **Termination**: No submission/instability termination conditions implemented yet.
 
-## Termination Conditions
+## API Summary
 
-- **Submission achieved**: Episode terminates when choke OR hyperextension sustained
-  - Choke: Force > 50.0 for 10+ consecutive steps
-  - Hyperextension: Random 0.1% chance per step (placeholder implementation)
-- **Episode timeout**: 1000 steps maximum (`max_episode_steps`)
-- **Physics instability**: Currently disabled (placeholder for future PyBullet integration)
-- **Early termination**: Winning agent gets terminated=True, losing agent also terminated
+- `reset(seed=None)` → `(observations, infos)` with deterministic seeding and per-agent metadata (`step`, `seed`, `physics_step`).
+- `step(actions)` → `(observations, rewards, terminated, truncated, infos)` using the deterministic physics adapter and reward scaffolding described above.
+- `close()` → Stops the physics adapter defensively.
 
-⚠️ **PLACEHOLDER STATUS**: Hyperextension termination is purely random, not based on actual joint physics.
+## Known Gaps / Next Steps
 
-## Technical Implementation
-
-**FULLY IMPLEMENTED:**
-- **Type safety**: Full mypy compliance with proper type annotations
-- **Error handling**: Clear ImportError for missing numpy/gymnasium dependencies  
-- **Multi-agent API**: Proper Dict-based spaces and return values
-- **Reward computation**: Complete hierarchical system with state tracking
-- **Configuration**: Comprehensive EnvConfig with sensible defaults
-- **Deterministic seeding**: Uses self.np_random for all random generation ensuring reproducible behavior
-- **Action scaling**: Actions scaled from [-1, 1] to [-max_torque, max_torque] as documented
-- **Observation bounds**: Contact positions properly bounded to [-1000, 1000] range
-
-**PLACEHOLDER/STUBBED:**
-- **Physics integration**: Uses DeterministicCounterAdapter (dummy physics)
-- **Observations**: Random dummy values instead of actual physics state
-- **Contact detection**: Simulated random contact forces and positions
-- **Choke detection**: Heuristic based on contact force thresholds
-- **Hyperextension**: Random chance instead of joint limit physics
-
-## Development Status
-
-**Phase 2 - Environment Framework** ✅ COMPLETE
-- Multi-agent Gymnasium API implemented and tested
-- Observation/action spaces defined and validated
-- Reward system architecture implemented
-- Configuration system working
-
-**Phase 3 - Physics Integration** 🔄 NEXT
-- Replace DeterministicCounterAdapter with PyBullet
-- Implement real contact detection and force calculation  
-- Add proper joint limit enforcement and hyperextension detection
-- Replace dummy observations with actual physics state
+- Replace placeholder observation values with real physics state (joint poses, velocities, contact summaries).
+- Expand the reward system with hierarchical BJJ components and proper termination events (submissions, loss of control, etc.).
+- Integrate a PyBullet-backed `PhysicsAdapter` once Phase 3 kicks off, including torque scaling and safety checks.
+- Add richer instrumentation (episode metrics, rolling averages) once observations/rewards are physically grounded.
 
 ## Usage Example
 
 ```python
 from bjjsim.env import BJJMultiAgentEnv
-import numpy as np
 
-# Create environment with default config
 env = BJJMultiAgentEnv()
-
-# Reset with seed for determinism
 obs, info = env.reset(seed=42)
-print(f"Observation shapes: {env.observation_space}")
-# Output: Dict('agent1': Box(90,), 'agent2': Box(90,))
+print(obs["agent1"])  # 12-dim placeholder observation as a list of floats
 
-# Sample actions and step
-actions = {agent: np.random.uniform(-1, 1, 12) for agent in env.agents}
-obs, rewards, terminated, truncated, infos = env.step(actions)
-print(f"Step rewards: {rewards}")
-print(f"Reward breakdown: {infos['agent1']['reward_components']}")
-
-# Environment info
-print(f"Episode step: {env.episode_step_count}")
-print(f"Agents: {env.agents}")  # ['agent1', 'agent2']
+zero_actions = {agent: [0.0] * env.config.action_dim for agent in env.agents}
+obs, rewards, terminated, truncated, infos = env.step(zero_actions)
+print(rewards["agent1"], infos["agent1"]["reward_components"])
 ```
-
-**Verified Working:** ✅ Import paths, API calls, observation dimensions, action spaces all tested and functional.

--- a/docs/planning/milestones.md
+++ b/docs/planning/milestones.md
@@ -2,6 +2,7 @@
 
 - M1: UI-first physics prototype renders two humanoids; contacts accessible; simple GUI overlays for contacts; local web UI shows frames and can reset/seed/start/stop (Phase 1 exit)
 - M2: Env step/reset returns typed observations; reward components logged; event annotations visible in GUI (Phase 2 exit)
+  - Progress: Deterministic placeholder multi-agent environment scaffold implemented with dependency-free spaces; needs physics-derived observations, hierarchical rewards, and GUI surfacing of reward events.
 - M3: PPO self-play trains for 100 iterations; no NaNs; rewards monotonic-ish (Phase 3 exit)
 - M4: In evaluation, agent maintains top position (Δz > threshold) for ≥5 consecutive seconds in ≥50% of episodes; overlays confirm events; thresholds validated (Phase 4 exit)
 

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -15,6 +15,7 @@ Deliverable now: UI skeleton with typed endpoints and placeholder data to enable
 
 Phase 2 — Environment and Rewards
 
+- Initial Gymnasium environment scaffold with deterministic placeholder observations/rewards (delivered in this iteration)
 - Multi-agent Gymnasium env; observation/action spaces; hierarchical reward components with logging
 - Web UI control panel (local) with start/stop/reset/seed; periodic frame preview; Playwright test scaffolding
 - Exit: Random-policy rollouts run; reward components tracked; UI smoke test passes headless

--- a/docs/requirements/overview.md
+++ b/docs/requirements/overview.md
@@ -5,11 +5,11 @@ Goal: Build a Python-based multi-agent self-play simulation to explore emergent 
 Key components
 
 - Physics: PyBullet with rigid humanoids, fixed time step, small non-zero lateral friction by default (configurable)
-- Environment: Custom multi-agent Gymnasium environment with typed observations/actions
+- Environment: Custom multi-agent environment designed for future Gymnasium compatibility with typed observations/actions
 - Rewards: Hierarchical — staying on top > control > joint hyperextension > choke; energy penalty; terminate on submission
 - RL: Self-play using Ray RLlib (PPO, torch); GUI for debugging; headless training
 
-Near-term deliverable: minimal FastAPI UI skeleton with deterministic test hooks (reset/seed, placeholder state, events) to unblock e2e test scaffolding.
+Near-term deliverable: initial multi-agent environment scaffold with deterministic test hooks (reset/seed, placeholder observations/rewards) to pair with the FastAPI UI and unblock end-to-end experiments.
 
 Scope (initial)
 

--- a/replit.md
+++ b/replit.md
@@ -7,7 +7,7 @@ BJJSim is a Python FastAPI web application that provides a simulation framework 
 ## Current Status
 
 - **Phase**: **Phase 2 Complete** ✅ - Environment and Rewards implemented
-- **Version**: 0.1.0  
+- **Version**: 0.1.0
 - **Framework**: FastAPI with Uvicorn server
 - **Frontend**: HTML templates with Jinja2 + real-time WebSocket updates
 - **Environment**: Multi-agent Gymnasium environment with hierarchical rewards

--- a/src/bjjsim/env/__init__.py
+++ b/src/bjjsim/env/__init__.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Mapping, Sequence
+
+import math
+import random
+
+from bjjsim.physics import DeterministicCounterAdapter, PhysicsAdapter
+
+
+@dataclass(slots=True)
+class ContinuousSpace:
+    """Simple representation of a continuous box space.
+
+    The class mirrors the small subset of Gymnasium's ``Box`` interface relied on
+    by our tests and documentation.  It stores the uniform lower/upper bounds and
+    exposes the shape of the space for light validation.
+    """
+
+    size: int
+    low: float
+    high: float
+
+    def __post_init__(self) -> None:
+        if self.size <= 0:
+            msg = "size must be positive"
+            raise ValueError(msg)
+        if self.low >= self.high:
+            msg = "low must be strictly less than high"
+            raise ValueError(msg)
+
+    @property
+    def shape(self) -> tuple[int]:
+        return (self.size,)
+
+    def clip(self, values: Sequence[float]) -> list[float]:
+        if len(values) != self.size:
+            msg = f"expected {self.size} values, received {len(values)}"
+            raise ValueError(msg)
+        return [min(max(float(v), self.low), self.high) for v in values]
+
+
+@dataclass(slots=True)
+class DictSpace:
+    """Mapping of agent identifiers to :class:`ContinuousSpace` definitions."""
+
+    spaces: dict[str, ContinuousSpace] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.spaces:
+            msg = "spaces must contain at least one entry"
+            raise ValueError(msg)
+
+    def __getitem__(self, key: str) -> ContinuousSpace:
+        return self.spaces[key]
+
+    def keys(self) -> list[str]:  # pragma: no cover - convenience
+        return list(self.spaces.keys())
+
+
+@dataclass(slots=True)
+class EnvConfig:
+    """Configuration for :class:`BJJMultiAgentEnv`.
+
+    The defaults intentionally keep the observation and action spaces small while
+    providing enough structure for deterministic testing.  Observation values are
+    bounded so the environment can participate in automated validation and future
+    RL experiments without additional wrappers.
+    """
+
+    agent_names: tuple[str, ...] = ("agent1", "agent2")
+    observation_dim: int = 12
+    observation_low: float = -1000.0
+    observation_high: float = 1000.0
+    action_dim: int = 6
+    action_low: float = -1.0
+    action_high: float = 1.0
+    max_episode_steps: int = 200
+    step_reward: float = 0.1
+    energy_penalty_scale: float = 0.05
+    physics_steps_per_action: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.agent_names:
+            msg = "agent_names must contain at least one agent"
+            raise ValueError(msg)
+        if self.observation_dim <= 0:
+            msg = "observation_dim must be positive"
+            raise ValueError(msg)
+        if self.action_dim <= 0:
+            msg = "action_dim must be positive"
+            raise ValueError(msg)
+        if self.observation_low >= self.observation_high:
+            msg = "observation_low must be strictly less than observation_high"
+            raise ValueError(msg)
+        if self.action_low >= self.action_high:
+            msg = "action_low must be strictly less than action_high"
+            raise ValueError(msg)
+        if self.max_episode_steps <= 0:
+            msg = "max_episode_steps must be positive"
+            raise ValueError(msg)
+        if self.physics_steps_per_action <= 0:
+            msg = "physics_steps_per_action must be positive"
+            raise ValueError(msg)
+
+
+class BJJMultiAgentEnv:
+    """Deterministic, dependency-free environment scaffold for BJJSim.
+
+    The environment exposes two symmetric agents and uses the deterministic
+    :class:`~bjjsim.physics.DeterministicCounterAdapter` by default.  It encodes
+    the current episode and physics step counts into the observations and
+    applies a simple reward made of a constant "step" reward minus an energy
+    penalty proportional to the L2 norm of each agent's action vector.  The goal
+    is to provide a stable target for wiring up future physics integrations and
+    self-play experiments while exercising the multi-agent plumbing.
+    """
+
+    metadata: ClassVar[dict[str, Any]] = {"render_modes": []}
+
+    def __init__(
+        self,
+        config: EnvConfig | None = None,
+        *,
+        physics: PhysicsAdapter | None = None,
+    ) -> None:
+        self.config = config or EnvConfig()
+        self._physics: PhysicsAdapter = physics or DeterministicCounterAdapter()
+        self.agents: tuple[str, ...] = tuple(self.config.agent_names)
+
+        obs_space = ContinuousSpace(
+            size=self.config.observation_dim,
+            low=self.config.observation_low,
+            high=self.config.observation_high,
+        )
+        self.observation_space = DictSpace({agent: obs_space for agent in self.agents})
+
+        action_space = ContinuousSpace(
+            size=self.config.action_dim,
+            low=self.config.action_low,
+            high=self.config.action_high,
+        )
+        self.action_space = DictSpace({agent: action_space for agent in self.agents})
+
+        self._seed_source = random.Random()
+        self._rng: random.Random = random.Random()
+        self._last_seed: int | None = None
+        self._episode_step: int = 0
+        self._total_steps: int = 0
+        self._episode_running: bool = False
+        self._last_actions: dict[str, list[float]] = {
+            agent: [0.0] * self.config.action_dim for agent in self.agents
+        }
+
+    @property
+    def physics(self) -> PhysicsAdapter:
+        """Return the physics adapter used by the environment."""
+
+        return self._physics
+
+    @property
+    def last_seed(self) -> int | None:
+        """Return the last seed applied via :meth:`reset`."""
+
+        return self._last_seed
+
+    @property
+    def episode_step_count(self) -> int:
+        """Number of steps taken in the current episode."""
+
+        return self._episode_step
+
+    @property
+    def total_steps(self) -> int:
+        """Total steps executed across all episodes since instantiation."""
+
+        return self._total_steps
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, list[float]], dict[str, dict[str, Any]]]:
+        del options  # Unused for API compatibility with Gymnasium-style resets.
+        if seed is None:
+            seed = self._seed_source.randrange(0, 2**32)
+        self._rng = random.Random(seed)
+        self._last_seed = int(seed)
+        self._episode_step = 0
+        self._episode_running = True
+        self._last_actions = {agent: [0.0] * self.config.action_dim for agent in self.agents}
+
+        self._physics.reset(seed)
+        self._physics.start(seed)
+
+        observations = self._build_observations()
+        infos = {
+            agent: {
+                "step": self._episode_step,
+                "seed": self._last_seed,
+                "physics_step": self._physics.step_count,
+            }
+            for agent in self.agents
+        }
+        return observations, infos
+
+    def step(
+        self, actions: Mapping[str, Sequence[float]]
+    ) -> tuple[
+        dict[str, list[float]],
+        dict[str, float],
+        dict[str, bool],
+        dict[str, bool],
+        dict[str, dict[str, Any]],
+    ]:
+        if not self._episode_running:
+            msg = "reset() must be called before step() and episode must be active"
+            raise RuntimeError(msg)
+
+        processed_actions = self._process_actions(actions)
+        self._last_actions = processed_actions
+
+        self._physics.step(self.config.physics_steps_per_action)
+        self._episode_step += 1
+        self._total_steps += 1
+
+        observations = self._build_observations()
+        rewards: dict[str, float] = {}
+        infos: dict[str, dict[str, Any]] = {}
+
+        for agent, action in processed_actions.items():
+            step_reward = self.config.step_reward
+            energy_penalty = -self.config.energy_penalty_scale * _l2_norm(action)
+            total_reward = step_reward + energy_penalty
+            rewards[agent] = total_reward
+            infos[agent] = {
+                "reward_components": {
+                    "step_reward": step_reward,
+                    "energy_penalty": energy_penalty,
+                },
+                "step": self._episode_step,
+                "physics_step": self._physics.step_count,
+            }
+
+        terminated = {agent: False for agent in self.agents}
+        truncated = {agent: False for agent in self.agents}
+
+        if self._episode_step >= self.config.max_episode_steps:
+            truncated = {agent: True for agent in self.agents}
+            self._episode_running = False
+            self._physics.stop()
+
+        return observations, rewards, terminated, truncated, infos
+
+    def close(self) -> None:  # pragma: no cover - defensive
+        self._physics.stop()
+
+    def _process_actions(self, actions: Mapping[str, Sequence[float]]) -> dict[str, list[float]]:
+        if set(actions.keys()) != set(self.agents):
+            msg = "actions must provide exactly one entry per agent"
+            raise ValueError(msg)
+
+        processed: dict[str, list[float]] = {}
+        for agent, value in actions.items():
+            space = self.action_space[agent]
+            try:
+                clipped = space.clip(value)
+            except TypeError as exc:  # Non-iterable provided
+                msg = f"action for {agent} must be an iterable of floats"
+                raise ValueError(msg) from exc
+            processed[agent] = clipped
+        return processed
+
+    def _build_observations(self) -> dict[str, list[float]]:
+        obs: dict[str, list[float]] = {}
+        base_step = float(self._episode_step)
+        physics_step = float(self._physics.step_count)
+        for idx, agent in enumerate(self.agents):
+            vec = [0.0] * self.config.observation_dim
+            vec[0] = base_step
+            if self.config.observation_dim > 1:
+                vec[1] = physics_step
+            if self.config.observation_dim > 2:
+                vec[2] = float(idx)
+            if self.config.observation_dim > 3:
+                remaining = self.config.observation_dim - 3
+                for pos in range(remaining):
+                    vec[3 + pos] = self._rng.uniform(
+                        self.config.observation_low,
+                        self.config.observation_high,
+                    )
+            obs[agent] = vec
+        return obs
+
+
+def _l2_norm(values: Sequence[float]) -> float:
+    return math.sqrt(sum(float(v) ** 2 for v in values))
+
+
+__all__ = [
+    "ContinuousSpace",
+    "DictSpace",
+    "EnvConfig",
+    "BJJMultiAgentEnv",
+]

--- a/src/bjjsim/env/__init__.py
+++ b/src/bjjsim/env/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, ClassVar, Mapping, Sequence
-
 import math
 import random
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
 
 from bjjsim.physics import DeterministicCounterAdapter, PhysicsAdapter
 

--- a/src/bjjsim/web/app.py
+++ b/src/bjjsim/web/app.py
@@ -113,7 +113,7 @@ def create_app() -> FastAPI:
 
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
     state = _ServerState()
-    physics: PhysicsAdapter = DeterministicCounterAdapter()  # type: ignore[assignment]
+    physics: PhysicsAdapter = DeterministicCounterAdapter()
     config = AppConfig()
 
     def index(request: Request) -> HTMLResponse:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,27 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
 import time
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Final
 
-import httpx
 import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+HTTPX_SPEC = importlib.util.find_spec("httpx")
+UVICORN_SPEC = importlib.util.find_spec("uvicorn")
+HAS_SERVER_DEPS = HTTPX_SPEC is not None and UVICORN_SPEC is not None
+
+if HAS_SERVER_DEPS:
+    import httpx
 
 BASE_HOST: Final[str] = "127.0.0.1"
 BASE_PORT: Final[int] = 8765
@@ -16,6 +29,8 @@ BASE_URL: Final[str] = f"http://{BASE_HOST}:{BASE_PORT}"
 
 
 def _wait_for_server(url: str, timeout_s: float = 10.0) -> None:
+    if not HAS_SERVER_DEPS:  # pragma: no cover - defensive guard
+        raise RuntimeError("server dependencies are not installed")
     start = time.monotonic()
     while time.monotonic() - start < timeout_s:
         try:
@@ -30,9 +45,11 @@ def _wait_for_server(url: str, timeout_s: float = 10.0) -> None:
 
 @pytest.fixture(scope="session")  # type: ignore[misc]
 def server_url() -> Iterator[str]:
+    if not HAS_SERVER_DEPS:
+        pytest.skip("uvicorn/httpx not installed; server fixture unavailable")
+
     env = os.environ.copy()
     env["UVICORN_WORKERS"] = "1"
-    # Start uvicorn as a subprocess using the app factory
     proc = subprocess.Popen(
         [
             sys.executable,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -10,10 +10,7 @@ from bjjsim.physics import DeterministicCounterAdapter
 
 
 def make_zero_actions(env: BJJMultiAgentEnv) -> dict[str, list[float]]:
-    return {
-        agent: [0.0 for _ in range(env.config.action_dim)]
-        for agent in env.agents
-    }
+    return {agent: [0.0 for _ in range(env.config.action_dim)] for agent in env.agents}
 
 
 def l2_norm(values: Sequence[float]) -> float:
@@ -74,7 +71,9 @@ def test_step_advances_physics_and_tracks_rewards() -> None:
     expected_penalty = -env.config.energy_penalty_scale * l2_norm(action_with_energy[env.agents[0]])
     for agent in env.agents:
         assert rewards_energy[agent] == pytest.approx(env.config.step_reward + expected_penalty)
-        assert infos_energy[agent]["reward_components"]["energy_penalty"] == pytest.approx(expected_penalty)
+        assert infos_energy[agent]["reward_components"]["energy_penalty"] == pytest.approx(
+            expected_penalty
+        )
 
     # Continue stepping until we hit the max and trigger truncation.
     _, _, _, truncated_final, _ = env.step(zero_actions)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from collections.abc import Sequence
+from typing import Mapping, cast
 
 import pytest
 
@@ -97,8 +98,8 @@ def test_invalid_actions_raise() -> None:
         env.step(missing_agent)
 
     # Non-iterable action values
-    non_iterable = {agent: 1.23 for agent in env.agents}  # type: ignore[assignment]
+    non_iterable_raw: dict[str, object] = {agent: 1.23 for agent in env.agents}
     with pytest.raises(ValueError):
-        env.step(non_iterable)
+        env.step(cast(Mapping[str, Sequence[float]], non_iterable_raw))
 
     env.close()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import pytest
+
+from bjjsim.env import BJJMultiAgentEnv, EnvConfig
+from bjjsim.physics import DeterministicCounterAdapter
+
+
+def make_zero_actions(env: BJJMultiAgentEnv) -> dict[str, list[float]]:
+    return {
+        agent: [0.0 for _ in range(env.config.action_dim)]
+        for agent in env.agents
+    }
+
+
+def l2_norm(values: Sequence[float]) -> float:
+    return math.sqrt(sum(float(v) ** 2 for v in values))
+
+
+def test_reset_returns_deterministic_observations() -> None:
+    env_a = BJJMultiAgentEnv()
+    obs_a, info_a = env_a.reset(seed=123)
+    env_b = BJJMultiAgentEnv()
+    obs_b, info_b = env_b.reset(seed=123)
+
+    assert set(obs_a.keys()) == set(env_a.agents)
+    assert set(obs_b.keys()) == set(env_b.agents)
+    for agent in env_a.agents:
+        assert obs_a[agent] == pytest.approx(obs_b[agent], rel=0, abs=1e-9)
+        assert info_a[agent]["seed"] == info_b[agent]["seed"] == env_a.last_seed == env_b.last_seed
+        assert len(obs_a[agent]) == env_a.config.observation_dim
+        assert all(isinstance(v, float) for v in obs_a[agent])
+
+    # Stepping with identical actions should remain deterministic.
+    actions = make_zero_actions(env_a)
+    obs_next_a, _, _, _, _ = env_a.step(actions)
+    obs_next_b, _, _, _, _ = env_b.step(actions)
+    for agent in env_a.agents:
+        assert obs_next_a[agent] == pytest.approx(obs_next_b[agent], rel=0, abs=1e-9)
+
+    env_a.close()
+    env_b.close()
+
+
+def test_step_advances_physics_and_tracks_rewards() -> None:
+    config = EnvConfig(max_episode_steps=3, physics_steps_per_action=2)
+    physics = DeterministicCounterAdapter()
+    env = BJJMultiAgentEnv(config=config, physics=physics)
+    env.reset(seed=7)
+
+    zero_actions = make_zero_actions(env)
+    obs, rewards, terminated, truncated, infos = env.step(zero_actions)
+
+    assert env.episode_step_count == 1
+    assert physics.step_count == 2  # physics_steps_per_action
+    for agent in env.agents:
+        assert rewards[agent] == pytest.approx(config.step_reward)
+        assert terminated[agent] is False
+        assert truncated[agent] is False
+        comps = infos[agent]["reward_components"]
+        assert comps["step_reward"] == pytest.approx(config.step_reward)
+        assert comps["energy_penalty"] == pytest.approx(0.0)
+        assert len(obs[agent]) == config.observation_dim
+
+    # Apply non-zero action to exercise penalty.
+    action_with_energy = {
+        agent: [1.0 if idx == 0 else 0.0 for idx in range(env.config.action_dim)]
+        for agent in env.agents
+    }
+    _, rewards_energy, _, _, infos_energy = env.step(action_with_energy)
+    expected_penalty = -env.config.energy_penalty_scale * l2_norm(action_with_energy[env.agents[0]])
+    for agent in env.agents:
+        assert rewards_energy[agent] == pytest.approx(env.config.step_reward + expected_penalty)
+        assert infos_energy[agent]["reward_components"]["energy_penalty"] == pytest.approx(expected_penalty)
+
+    # Continue stepping until we hit the max and trigger truncation.
+    _, _, _, truncated_final, _ = env.step(zero_actions)
+    assert all(truncated_final.values())
+    with pytest.raises(RuntimeError):
+        env.step(zero_actions)
+
+    env.close()
+
+
+def test_invalid_actions_raise() -> None:
+    env = BJJMultiAgentEnv()
+    env.reset(seed=5)
+
+    wrong_shape = {agent: [0.0 for _ in range(env.config.action_dim + 1)] for agent in env.agents}
+    with pytest.raises(ValueError):
+        env.step(wrong_shape)
+
+    missing_agent = {env.agents[0]: [0.0 for _ in range(env.config.action_dim)]}
+    with pytest.raises(ValueError):
+        env.step(missing_agent)
+
+    # Non-iterable action values
+    non_iterable = {agent: 1.23 for agent in env.agents}  # type: ignore[assignment]
+    with pytest.raises(ValueError):
+        env.step(non_iterable)
+
+    env.close()

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import importlib.util
 from typing import Any
 
-from fastapi.testclient import TestClient
+import pytest
 
-from bjjsim.web.app import create_app
+FASTAPI_SPEC = importlib.util.find_spec("fastapi")
+PIL_SPEC = importlib.util.find_spec("PIL")
+if FASTAPI_SPEC is None or PIL_SPEC is None:
+    pytest.skip("fastapi/Pillow not installed", allow_module_level=True)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from bjjsim.web.app import create_app  # noqa: E402
+from PIL import Image  # noqa: E402
 
 
 def test_reset_and_state_roundtrip() -> None:
@@ -56,9 +64,8 @@ def test_frame_endpoint_png() -> None:
     assert client.post("/api/sim/step", json={"num_steps": 5}).status_code == 200
     res2 = client.get("/api/frames/current")
     assert res2.status_code == 200
-    from io import BytesIO
 
-    from PIL import Image
+    from io import BytesIO
 
     img = Image.open(BytesIO(res2.content))
     pixel = img.getpixel((0, 0))

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -11,8 +11,9 @@ if FASTAPI_SPEC is None or PIL_SPEC is None:
     pytest.skip("fastapi/Pillow not installed", allow_module_level=True)
 
 from fastapi.testclient import TestClient  # noqa: E402
-from bjjsim.web.app import create_app  # noqa: E402
 from PIL import Image  # noqa: E402
+
+from bjjsim.web.app import create_app  # noqa: E402
 
 
 def test_reset_and_state_roundtrip() -> None:


### PR DESCRIPTION
## Summary
- replace the Gymnasium/Numpy scaffold with a dependency-free `BJJMultiAgentEnv` that provides simple `ContinuousSpace`/`DictSpace` helpers and deterministic seeding
- adjust unit tests and fixtures to run against the standard-library environment while skipping optional web/UI tests when FastAPI tooling is missing
- document the new dependency-free posture and optional extras across the README and architecture/planning docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c98beae22483279ab2aa2dada596b7